### PR TITLE
Proposed fix for [BUG] Deployment expects layer in the wrong region #2

### DIFF
--- a/deploy.mjs
+++ b/deploy.mjs
@@ -290,7 +290,7 @@ async function deploy () {
         div++
     }
 
-    const lambda = new AWS.Lambda({ region: 'us-east-1' })
+    const lambda = new AWS.Lambda({ region: options.region || 'us-east-1' })
 
     // check if lambda exists
     const exists = await lambda.getFunction({

--- a/package.json
+++ b/package.json
@@ -12,18 +12,18 @@
   "type": "module",
   "devDependencies": {},
   "peerDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@aws-sdk/client-lambda": "^3.322.0",
+    "@aws-sdk/client-lambda": "^3.511.0",
     "adm-zip": "^0.5.10",
-    "chalk": "^5.2.0",
-    "commander": "^10.0.1",
-    "deep-equal": "^2.2.1",
-    "elysia": "^0.4.13",
-    "inquirer": "^9.2.0",
-    "superagent": "^8.0.9",
-    "yaml": "^2.2.2"
+    "chalk": "^5.3.0",
+    "commander": "^12.0.0",
+    "deep-equal": "^2.2.3",
+    "elysia": "^0.8.17",
+    "inquirer": "^9.2.14",
+    "superagent": "^8.1.2",
+    "yaml": "^2.3.4"
   },
   "bin": {
     "elysia-lambda": "./deploy.mjs"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.8",
   "repository": {
     "type": "https+git",
-    "url": "https://github.com/TotalTechGeek/elysia-lambda"
+    "url": "https://github.com/rainstormai7/elysia-lambda.git"
   },
   "description": "A plugin for Elysia to deploy to AWS Lambda",
   "module": "index.ts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "elysia-lambda",
   "author": "Jesse Daniel Mitchell",
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "repository": {
     "type": "https+git",
     "url": "https://github.com/TotalTechGeek/elysia-lambda"


### PR DESCRIPTION
Proposed Fix For Issue: [[BUG] Deployment expects layer in the wrong region #2](https://github.com/TotalTechGeek/elysia-lambda/issues/2)

1. Added the option region `options.region` 
2. Upgrade All Package Dependencies to latest version

Then Tested with the following:-

1. Create a new Elysia project `bun create elysia app`
2. Installed the local version of this update repo package `bun add ../../elysia-lambda/`
3. Updated the resulting `app/src/index.ts`
```typescript
import { Elysia } from 'elysia'
import { lambda } from 'elysia-lambda'

const app = new Elysia()
    .use(lambda())
    .get("/", () => "Hello Elysia").listen(3000);

console.log(
  `🦊 Elysia is running at ${app.server?.hostname}:${app.server?.port}`
);
```
4. Initialised the AWS Lambda YAML config `bunx elysia-lambda --init`
5. See the resulting YAML
```yaml
deploy: src/index.ts
name: elysia-lambda
region: eu-west-2
memory: "256"
arch: arm64
description: Elysia Lambda
role: arn:aws:iam::[AWS_ACCOUNT_ID]:role/LambdaAWSRole
layers:
  - arn:aws:lambda:eu-west-2:[AWS_ACCOUNT_ID]:layer:bun:5
```
6. Deployed the Lambda into an AWS Region Different to the Default of `us-east-1` - `run bun deploy`
7. Create an AWS Lambda Function URL to test
8. Go the URL in the browser to test the new endpoint:-
![image](https://github.com/TotalTechGeek/elysia-lambda/assets/153618391/18f29fcb-adcb-4cb9-9920-49c72de2c5e4)



